### PR TITLE
Add semantic versioning workflow

### DIFF
--- a/.github/workflows/pull-request-tests-workflow.yml
+++ b/.github/workflows/pull-request-tests-workflow.yml
@@ -6,11 +6,9 @@
 # separate terms of service, privacy policy, and support
 # documentation.
 
-name: Java CI with Maven
+name: Pull Request test run
 
 on:
-  push:
-    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
 
@@ -27,5 +25,5 @@ jobs:
         java-version: '21'
         distribution: 'temurin'
         cache: maven
-    - name: Build with Maven
-      run: mvn -B package --file pom.xml
+    - name: Test with Maven
+      run: mvn -B test --file pom.xml

--- a/.github/workflows/semantic-versioning-workflow.yml
+++ b/.github/workflows/semantic-versioning-workflow.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - test-semantic-versioning
 
 jobs:
   build:
@@ -24,27 +23,14 @@ jobs:
       - name: Increment version
         uses: paulhatch/semantic-version@v5.4.0
         with:
-          # The prefix to use to identify tags
           tag_prefix: "v"
-          # A string which, if present in a git commit, indicates that a change represents a
-          # major (breaking) change, supports regular expressions wrapped with '/'
           major_pattern: "(MAJOR)"
-          # Same as above except indicating a minor change, supports regular expressions wrapped with '/'
           minor_pattern: "(MINOR)"
-          # A string to determine the format of the version output
           version_format: "${major}.${minor}.${patch}"
-          # If this is set to true, *every* commit will be treated as a new version.
           bump_each_commit: false
-          # If bump_each_commit is also set to true, setting this value will cause the version to increment only if the pattern specified is matched.
           bump_each_commit_patch_pattern: ""
-          # If true, the body of commits will also be searched for major/minor patterns to determine the version type.
           search_commit_body: false
-          # The output method used to generate list of users, 'csv' or 'json'.
           user_format_type: "csv"
-          # Prevents pre-v1.0.0 version from automatically incrementing the major version.
-          # If enabled, when the major version is 0, major releases will be treated as minor and minor as patch. Note that the version_type output is unchanged.
           enable_prerelease_mode: true
-          # If enabled, diagnostic information will be added to the action output.
           debug: true
-          # If true, the branch will be used to select the maximum version.
           version_from_branch: false

--- a/.github/workflows/semantic-versioning-workflow.yml
+++ b/.github/workflows/semantic-versioning-workflow.yml
@@ -1,0 +1,50 @@
+name: Semantic versioning workflow
+
+on:
+  push:
+    branches:
+      - main
+      - test-semantic-versioning
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: maven
+      - name: Build with Maven
+        run: mvn -B package --file pom.xml
+      - name: Increment version
+        uses: paulhatch/semantic-version@v5.4.0
+        with:
+          # The prefix to use to identify tags
+          tag_prefix: "v"
+          # A string which, if present in a git commit, indicates that a change represents a
+          # major (breaking) change, supports regular expressions wrapped with '/'
+          major_pattern: "(MAJOR)"
+          # Same as above except indicating a minor change, supports regular expressions wrapped with '/'
+          minor_pattern: "(MINOR)"
+          # A string to determine the format of the version output
+          version_format: "${major}.${minor}.${patch}"
+          # If this is set to true, *every* commit will be treated as a new version.
+          bump_each_commit: false
+          # If bump_each_commit is also set to true, setting this value will cause the version to increment only if the pattern specified is matched.
+          bump_each_commit_patch_pattern: ""
+          # If true, the body of commits will also be searched for major/minor patterns to determine the version type.
+          search_commit_body: false
+          # The output method used to generate list of users, 'csv' or 'json'.
+          user_format_type: "csv"
+          # Prevents pre-v1.0.0 version from automatically incrementing the major version.
+          # If enabled, when the major version is 0, major releases will be treated as minor and minor as patch. Note that the version_type output is unchanged.
+          enable_prerelease_mode: true
+          # If enabled, diagnostic information will be added to the action output.
+          debug: true
+          # If true, the branch will be used to select the maximum version.
+          version_from_branch: false


### PR DESCRIPTION
This commit introduces a GitHub Actions workflow for semantic versioning. It automates version increments based on commit messages and other configuration rules, improving the release process. The workflow includes Java setup, Maven build, and version tagging using semantic rules.