### PR TITLE
Refactor response assertions with static factory method

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.truenvy</groupId>
     <artifactId>reqres-api-tests-pet-project</artifactId>
-    <version>0.0.4</version>
+    <version>0.0.5</version>
 
     <properties>
         <maven.compiler.source>21</maven.compiler.source>

--- a/src/main/java/org/truenvy/reqres/asserters/SingleUserResponseAsserter.java
+++ b/src/main/java/org/truenvy/reqres/asserters/SingleUserResponseAsserter.java
@@ -3,9 +3,8 @@ package org.truenvy.reqres.asserters;
 import io.qameta.allure.Step;
 import io.restassured.response.Response;
 import lombok.extern.slf4j.Slf4j;
+import org.assertj.core.api.Assertions;
 import org.truenvy.reqres.rest.models.responses.users.get.GetSingleUserResponse;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * A utility class to assert properties of the response returned from
@@ -19,13 +18,17 @@ public class SingleUserResponseAsserter {
     private final Response response;
     private final GetSingleUserResponse getSingleUserResponse;
 
-    public SingleUserResponseAsserter(Response response) {
+    private SingleUserResponseAsserter(Response response) {
         this.response = response;
         if (response.getStatusCode() == 200) {
             this.getSingleUserResponse = response.as(GetSingleUserResponse.class);
         } else {
             this.getSingleUserResponse = null;
         }
+    }
+
+    public static SingleUserResponseAsserter assertThat(Response response) {
+        return new SingleUserResponseAsserter(response);
     }
 
     @Step("API response should have status code: {statusCode}")
@@ -38,28 +41,28 @@ public class SingleUserResponseAsserter {
     @Step("API response should have id: {id}}")
     public SingleUserResponseAsserter toHaveIdNotNull(String id) {
         log.info("API response should have id: {}", id);
-        assertThat(this.getSingleUserResponse.data().id()).isEqualTo(Integer.parseInt(id));
+        Assertions.assertThat(this.getSingleUserResponse.data().id()).isEqualTo(Integer.parseInt(id));
         return this;
     }
 
     @Step("API response should have email not null")
     public SingleUserResponseAsserter toHaveEmailNotNull() {
         log.info("API response should have email not null");
-        assertThat(this.getSingleUserResponse.data().email()).isNotNull();
+        Assertions.assertThat(this.getSingleUserResponse.data().email()).isNotNull();
         return this;
     }
 
     @Step("API response should have first name not null")
     public SingleUserResponseAsserter toHaveFirstNameNotNull() {
         log.info("API request should have first name not null");
-        assertThat(this.getSingleUserResponse.data().firstName()).isNotNull();
+        Assertions.assertThat(this.getSingleUserResponse.data().firstName()).isNotNull();
         return this;
     }
 
     @Step("API response should have last name not null")
     public SingleUserResponseAsserter toHaveLastNameNotNull() {
         log.info("API response should have last name not null");
-        assertThat(this.getSingleUserResponse.data().lastName()).isNotNull();
+        Assertions.assertThat(this.getSingleUserResponse.data().lastName()).isNotNull();
         return this;
     }
 }

--- a/src/test/java/org/truenvy/reqres/ReqresGetSingleUserTest.java
+++ b/src/test/java/org/truenvy/reqres/ReqresGetSingleUserTest.java
@@ -6,8 +6,9 @@ import io.qameta.allure.Stories;
 import io.qameta.allure.Story;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.truenvy.reqres.asserters.SingleUserResponseAsserter;
 import org.truenvy.reqres.base.AbstractBaseTest;
+
+import static org.truenvy.reqres.asserters.SingleUserResponseAsserter.assertThat;
 
 @Epics({
         @Epic("Reqres")
@@ -29,7 +30,7 @@ public class ReqresGetSingleUserTest extends AbstractBaseTest {
         var singleUserResponse = reqresApiClient.getUserById(userId);
 
         // then
-        new SingleUserResponseAsserter(singleUserResponse)
+        assertThat(singleUserResponse)
                 .toHaveStatusCode(OK)
                 .toHaveIdNotNull(userId)
                 .toHaveEmailNotNull()
@@ -47,7 +48,7 @@ public class ReqresGetSingleUserTest extends AbstractBaseTest {
         var singleUserResponse = reqresApiClient.getUserById(userId);
 
         // then
-        new SingleUserResponseAsserter(singleUserResponse)
+        assertThat(singleUserResponse)
                 .toHaveStatusCode(NOT_FOUND);
     }
 }


### PR DESCRIPTION
Replaced explicit instantiation of SingleUserResponseAsserter with a static factory method for cleaner and more expressive test code. Updated related imports and made internal adjustments to ensure consistency. Bumped version to 0.0.5 to reflect these changes.